### PR TITLE
Remove deprecated `getConnectionString` in favor of `getUri`

### DIFF
--- a/generators/app/templates/javascript/dbHandler.js
+++ b/generators/app/templates/javascript/dbHandler.js
@@ -7,7 +7,7 @@ const mongodb = new MongoMemoryServer.MongoMemoryServer();
  * Connects to the in-memory database.
  */
 export const connect = async () => {
-  const uri = await mongodb.getConnectionString();
+  const uri = await mongodb.getUri();
 
   const mongooseOpts = {
     useNewUrlParser: true,

--- a/generators/app/templates/typescript/dbHandler.ts
+++ b/generators/app/templates/typescript/dbHandler.ts
@@ -7,7 +7,7 @@ const mongodb = new MongoMemoryServer();
  * Connects to the in-memory database.
  */
 export const connect = async () => {
-  const uri = await mongodb.getConnectionString();
+  const uri = await mongodb.getUri();
 
   const mongooseOpts = {
     useNewUrlParser: true,


### PR DESCRIPTION
This replaces the deprecated `MongoMemoryReplSet.getConnectionString` with the
new `MongoMemoryReplSet.getUri` implementation.

`getConnectionString` was deprecated in [Release 6.9.0](https://github.com/nodkz/mongodb-memory-server/releases/tag/v6.9.0)

This closes #45 