### PR TITLE
chore: Add missing package dependencies

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -143,7 +143,7 @@ module.exports = class extends Generator {
       'express',
       'apollo-server',
       'apollo-server-express',
-      'graphql',
+      'graphql@14.5.8',
       'graphql-import-node',
       'graphql-tag',
       '@graphql-tools/merge',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -138,7 +138,7 @@ module.exports = class extends Generator {
         ],
       },
       resolutions: {
-        graphql: '14.5.8'
+        graphql: '14.5.8',
       },
     });
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -138,7 +138,7 @@ module.exports = class extends Generator {
         ],
       },
       resolutions: {
-        graphql: '14.5.8',
+        graphql: '^15.3.0',
       },
     });
 
@@ -146,7 +146,7 @@ module.exports = class extends Generator {
       'express',
       'apollo-server',
       'apollo-server-express',
-      'graphql@14.5.8',
+      'graphql@^15.3.0',
       'graphql-import-node',
       'graphql-tag',
       '@graphql-tools/merge',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -145,6 +145,7 @@ module.exports = class extends Generator {
       'apollo-server-express',
       'graphql',
       'graphql-import-node',
+      'graphql-tag',
       '@graphql-tools/merge',
       'dotenv',
     ]);

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -137,6 +137,9 @@ module.exports = class extends Generator {
           "!src/server" + fileExtension,
         ],
       },
+      resolutions: {
+        graphql: '14.5.8'
+      },
     });
 
     install([

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -143,6 +143,7 @@ module.exports = class extends Generator {
       'express',
       'apollo-server',
       'apollo-server-express',
+      'graphql',
       'graphql-import-node',
       '@graphql-tools/merge',
       'dotenv',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -143,6 +143,7 @@ module.exports = class extends Generator {
       'express',
       'apollo-server',
       'apollo-server-express',
+      'graphql',
       'graphql-import-node',
       'graphql-tag',
       '@graphql-tools/merge',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -143,7 +143,6 @@ module.exports = class extends Generator {
       'express',
       'apollo-server',
       'apollo-server-express',
-      'graphql@14.5.8',
       'graphql-import-node',
       'graphql-tag',
       '@graphql-tools/merge',

--- a/generators/app/templates/javascript/userResolver.test.js
+++ b/generators/app/templates/javascript/userResolver.test.js
@@ -1,5 +1,5 @@
+import { mergeTypeDefs } from '@graphql-tools/merge';
 import EasyGraphQLTester from 'easygraphql-tester';
-import mergeGraphqlSchemas from 'merge-graphql-schemas';
 import faker from 'faker';
 import bcrypt from 'bcrypt';
 
@@ -12,7 +12,7 @@ import userResolver from '../../src/graphql/resolvers/userResolver.js';
 
 dotenv.config();
 
-const schema = mergeGraphqlSchemas.mergeTypes([user], { all: true });
+const schema = mergeTypeDefs([user], { all: true });
 
 let tester = null;
 beforeAll(async () => {

--- a/generators/app/templates/javascript/userResolver.test.js
+++ b/generators/app/templates/javascript/userResolver.test.js
@@ -12,7 +12,7 @@ import userResolver from '../../src/graphql/resolvers/userResolver.js';
 
 dotenv.config();
 
-const schema = mergeTypeDefs([user], { all: true });
+const schema = mergeTypeDefs([user], { useSchemaDefinition: true, forceSchemaDefinition: true });
 
 let tester = null;
 beforeAll(async () => {

--- a/generators/app/templates/typescript/userResolver.test.ts
+++ b/generators/app/templates/typescript/userResolver.test.ts
@@ -12,7 +12,7 @@ import userResolver from '../../src/graphql/resolvers/userResolver';
 
 dotenv.config();
 
-const schema = mergeTypeDefs([user], { all: true });
+const schema = mergeTypeDefs([user], { useSchemaDefinition: true, forceSchemaDefinition: true });
 
 let tester = null;
 beforeAll(async () => {

--- a/generators/app/templates/typescript/userResolver.test.ts
+++ b/generators/app/templates/typescript/userResolver.test.ts
@@ -1,5 +1,5 @@
+import { mergeTypeDefs } from '@graphql-tools/merge';
 import EasyGraphQLTester from 'easygraphql-tester';
-import { mergeTypes } from 'merge-graphql-schemas';
 import faker from 'faker';
 import bcrypt from 'bcrypt';
 
@@ -12,7 +12,7 @@ import userResolver from '../../src/graphql/resolvers/userResolver';
 
 dotenv.config();
 
-const schema = mergeTypes([user], { all: true });
+const schema = mergeTypeDefs([user], { all: true });
 
 let tester = null;
 beforeAll(async () => {


### PR DESCRIPTION
Hi @CrimsonNynja 👋 

Found your repo on #hacktoberfest list. Please have a look the PR solves the issue or not.

---

**Before**

```
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning " > @graphql-tools/merge@6.2.5" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "@graphql-tools/merge > @graphql-tools/schema@7.0.0" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning "@graphql-tools/merge > @graphql-tools/utils@7.0.1" has unmet peer dependency "graphql@^14.0.0 || ^15.0.0".
warning " > apollo-server@2.18.2" has unmet peer dependency "graphql@^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "apollo-server > apollo-server-core@2.18.2" has unmet peer dependency "graphql@^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning " > apollo-server-express@2.18.2" has unmet peer dependency "graphql@^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "apollo-server > graphql-subscriptions@1.1.0" has unmet peer dependency "graphql@^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0".
warning "apollo-server > graphql-tools@4.0.8" has unmet peer dependency "graphql@^0.13.0 || ^14.0.0 || ^15.0.0".
warning "apollo-server > apollo-server-core > apollo-cache-control@0.11.3" has unmet peer dependency "graphql@^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "apollo-server > apollo-server-core > apollo-graphql@0.6.0" has unmet peer dependency "graphql@^14.2.1 || ^15.0.0".
warning "apollo-server > apollo-server-core > apollo-server-errors@2.4.2" has unmet peer dependency "graphql@^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "apollo-server > apollo-server-core > apollo-server-plugin-base@0.10.1" has unmet peer dependency "graphql@^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "apollo-server > apollo-server-core > apollo-server-types@0.6.0" has unmet peer dependency "graphql@^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "apollo-server > apollo-server-core > apollo-tracing@0.11.4" has unmet peer dependency "graphql@^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "apollo-server > apollo-server-core > graphql-extensions@0.12.5" has unmet peer dependency "graphql@^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "apollo-server > apollo-server-core > graphql-tag@2.11.0" has unmet peer dependency "graphql@^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "apollo-server > apollo-server-core > graphql-upload@8.1.0" has unmet peer dependency "graphql@0.13.1 - 14".
warning "apollo-server > apollo-server-core > subscriptions-transport-ws@0.9.18" has unmet peer dependency "graphql@>=0.10.0".
warning "apollo-server > graphql-tools > apollo-link@1.2.14" has unmet peer dependency "graphql@^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning "apollo-server > graphql-tools > apollo-utilities@1.3.4" has unmet peer dependency "graphql@^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0".
warning " > easygraphql-tester@5.1.6" has unmet peer dependency "graphql@^0.13.0 || ^14.0.0".
warning " > graphql-import-node@0.0.4" has unmet peer dependency "graphql@*".
warning " > jest-transform-graphql@2.1.0" has unmet peer dependency "graphql-tag@^2.0.0".
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
warning No license field
success Saved 4 new dependencies.
info Direct dependencies
├─ @types/mongoose@5.7.36
└─ mongodb-memory-server@6.9.2
info All dependencies
├─ @types/bson@4.0.3
├─ @types/mongodb@3.5.31
├─ @types/mongoose@5.7.36
└─ mongodb-memory-server@6.9.2
✨  Done in 6.61s.
yarn install v1.22.4
warning package.json: No license field
warning No license field
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.50s.
```

**After**

```
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning "apollo-server > graphql-subscriptions@1.1.0" has incorrect peer dependency "graphql@^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0".
warning "apollo-server > apollo-server-core > graphql-upload@8.1.0" has incorrect peer dependency "graphql@0.13.1 - 14".
warning " > easygraphql-tester@5.1.6" has incorrect peer dependency "graphql@^0.13.0 || ^14.0.0".
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
warning No license field
success Saved 4 new dependencies.
info Direct dependencies
├─ @types/mongoose@5.7.36
└─ mongodb-memory-server@6.9.2
info All dependencies
├─ @types/bson@4.0.3
├─ @types/mongodb@3.5.31
├─ @types/mongoose@5.7.36
└─ mongodb-memory-server@6.9.2
✨  Done in 5.38s.
yarn install v1.22.4
warning package.json: No license field
warning No license field
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.57s.
```

Closes #52 .